### PR TITLE
商品一覧の表示修正

### DIFF
--- a/app/views/shared/_main_top.html.haml
+++ b/app/views/shared/_main_top.html.haml
@@ -139,7 +139,9 @@
 
       .pickupbrand__new
         = link_to category_path(@category) do
-          アーカイバ
+          %span
+            = @category.name
+          の商品一覧
 
       .pickupbrand__items
         %ul.pickupbrand__top

--- a/app/views/shared/_main_top.html.haml
+++ b/app/views/shared/_main_top.html.haml
@@ -141,7 +141,7 @@
         = link_to category_path(@category) do
           %span
             = @category.name
-          の商品一覧
+          の新着商品
 
       .pickupbrand__items
         %ul.pickupbrand__top


### PR DESCRIPTION
# What
トップページのピックアップカテゴリーの表記を「アーカイバ」から「カテゴリー名」に変更

# Why
このほうがリンク先の内容を的確に表しているため