### PR TITLE
商品購入後の商品詳細ページの表示更新

### DIFF
--- a/app/assets/stylesheets/_show_item.scss
+++ b/app/assets/stylesheets/_show_item.scss
@@ -145,6 +145,14 @@
         border-radius: 5px;
         width: 150px;
       }
+      &__soldout {
+        background: lightcoral;
+        font-size: 18px;
+        color: $white;
+        display: block;
+        border-radius: 5px;
+        width: 250px;
+      }
     }
   }
   .item_comment_wrapper{

--- a/app/assets/stylesheets/_show_item.scss
+++ b/app/assets/stylesheets/_show_item.scss
@@ -153,6 +153,14 @@
         border-radius: 5px;
         width: 250px;
       }
+      &__preparation {
+        background: $green;
+        font-size: 18px;
+        color: $white;
+        display: block;
+        border-radius: 5px;
+        width: 300px;
+      }
     }
   }
   .item_comment_wrapper{

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -72,11 +72,10 @@
         = link_to "商品編集", edit_item_path, class: "item_wrapper__btn__edit"
         = link_to "商品削除", item_path(@item), class: "item_wrapper__btn__destroy", method: :delete
       - elsif @item.buyer_id?
-        .SoldOutView
+        .item_wrapper__btn__soldout
           売り切れました
       - else
         = link_to "商品購入", item_purchase_path(params[:id]), class: "item_wrapper__btn__buy"
-
 
 
 

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -71,8 +71,12 @@
       - if @item.saler_id == current_user.id
         = link_to "商品編集", edit_item_path, class: "item_wrapper__btn__edit"
         = link_to "商品削除", item_path(@item), class: "item_wrapper__btn__destroy", method: :delete
+      - elsif @item.buyer_id?
+        .SoldOutView
+          売り切れました
       - else
         = link_to "商品購入", item_purchase_path(params[:id]), class: "item_wrapper__btn__buy"
+
 
 
 

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -68,7 +68,13 @@
         %i.fas.fa-flag
         %p 不適切な商品の通報
     .item_wrapper__btn
-      - if @item.saler_id == current_user.id
+      - if @item.saler_id == current_user.id && @item.buyer_id?
+        .item_wrapper__btn__preparation
+          購入希望者の手続き中です
+      - elsif @item.buyer_id == current_user.id
+        .item_wrapper__btn__preparation
+          購入手続き中です
+      - elsif @item.saler_id == current_user.id
         = link_to "商品編集", edit_item_path, class: "item_wrapper__btn__edit"
         = link_to "商品削除", item_path(@item), class: "item_wrapper__btn__destroy", method: :delete
       - elsif @item.buyer_id?


### PR DESCRIPTION
# What
条件分岐により、商品購入後の詳細ページに購入ボタンが表示されないようにする。
・出品者が購入済の詳細ページを開いた時・・・「購入希望者の手続き中です」
・購入者が購入済の詳細ページを開いた時・・・「購入手続き中です」
・出品者が未購入品のページを開いた時・・・編集、削除ボタン（これまで通り）
・出品者・購入者以外が購入済の詳細ページを開いた時・・・「売り切れました」
・上記4つ以外・・・商品購入ボタン（これまで通り）

# Why
購入手続き済の商品への多重購入が発生しないようにするため。
購入手続きされた場合に、商品が売れたことを出品者側が分かるようにするため
購入手続きした場合に、商品を購入済みであることを購入者側が分かるようにするため

<img width="668" alt="スクリーンショット 2020-03-03 11 08 29" src="https://user-images.githubusercontent.com/60127758/75737388-f5b92e00-5d42-11ea-99ac-8cc530103cce.png">
<img width="1047" alt="スクリーンショット 2020-03-03 11 11 38" src="https://user-images.githubusercontent.com/60127758/75737447-15e8ed00-5d43-11ea-8aad-326bea2d786e.png">
<img width="1048" alt="スクリーンショット 2020-03-03 11 10 00" src="https://user-images.githubusercontent.com/60127758/75737451-18e3dd80-5d43-11ea-90de-5433e366d993.png">
<img width="1058" alt="スクリーンショット 2020-03-03 11 09 40" src="https://user-images.githubusercontent.com/60127758/75737454-1a150a80-5d43-11ea-9fbc-1ab559cefb11.png">



